### PR TITLE
Support proper type-checking of the dataclass transform `datadict.dataclass`

### DIFF
--- a/datadict/dataclass.py
+++ b/datadict/dataclass.py
@@ -3,7 +3,11 @@
 # Standard library imports
 import dataclasses
 
+# Third party imports
+from typing_extensions import dataclass_transform
 
+
+@dataclass_transform()
 def dataclass(cls=None, **kwargs):
     """Add item access to attributes"""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ requires           = [
 
 
 [tool.flit.metadata.requires-extra]
-dev                = ["black", "bumpversion", "flake8", "flit", "interrogate", "isort", "mypy", "pre-commit"]
+dev                = ["black", "bumpversion", "flake8", "flit", "interrogate", "isort", "mypy", "pre-commit", "pyright"]
 doc                = ["mkdocs"]
-test               = ["black", "flake8", "interrogate", "isort", "mypy", "pytest", "pytest-cov", "tox"]
+test               = ["black", "flake8", "interrogate", "isort", "mypy", "pyright", "pytest", "pytest-cov", "tox"]
 
 
 [tool.interrogate]
@@ -49,7 +49,7 @@ fail-under = 100
 verbose = 0
 
 [tool.pyright]
-include=["tests"]
-typeCheckingMode= "off"
+include = ["tests"]
+typeCheckingMode = "off"
 reportGeneralTypeIssues = "error"
 reportMissingImports = "none"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,19 +16,19 @@ classifiers        = [
     "Operating System :: MacOS",
     "Operating System :: Microsoft",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Code Generators",
 ]
 keywords           = "dataclass dict dictionary item access"
 
 # Requirements
-requires-python    = ">=3.6"
+requires-python    = ">=3.7"
 requires           = [
-    "dataclasses; python_version < '3.7'",
+    "typing_extensions",
 ]
 
 
@@ -47,3 +47,9 @@ ignore-private = false
 ignore-module = false
 fail-under = 100
 verbose = 0
+
+[tool.pyright]
+include=["tests"]
+typeCheckingMode= "off"
+reportGeneralTypeIssues = "error"
+reportMissingImports = "none"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py, black, flake8, interrogate, isort
+envlist = py, black, flake8, interrogate, isort, pyright
 
 
 [testenv]
@@ -34,3 +34,7 @@ commands = python -m isort --check datadict/
 [testenv:mypy]
 deps = mypy
 commands = python -m mypy datadict/
+
+[testenv:pyright]
+deps = pyright
+commands = python -m pyright


### PR DESCRIPTION
Fixes #1.

Also add pyright to tox and tool config in `pyrightconfig.json` to test this fix.
Introducing the dependency `typing_extensions` requires dropping support for Python 3.6.

Note that the new tox env `pyright` is flaky on Windows due to https://github.com/RobertCraigie/pyright-python/issues/45, but works as expected on Linux (tested in GitHub Codespaces). The pyright tox env purposefully typechecks `tests/test_datadict.py`, because that is where the error `error: Expected no arguments to "Point" constructor (reportGeneralTypeIssues)` pops if the `@dataclass_transform()` decorator is missing (or commented out) in `datadict/datadict.py`.